### PR TITLE
Allow discovery version ^0.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.4",
         "php-http/httplug": "^1.0",
-        "php-http/discovery": "~0.6.4",
+        "php-http/discovery": "~0.6.4|^0.7",
         "guzzlehttp/guzzle": "^5.1"
     },
     "require-dev": {


### PR DESCRIPTION
Composer was giving me errors: 

```
Problem 1
    - php-http/guzzle5-adapter dev-master requires php-http/discovery ~0.6.4 -> satisfiable by php-http/discovery[v0.6.4].
    - php-http/guzzle5-adapter dev-master requires php-http/discovery ~0.6.4 -> satisfiable by php-http/discovery[v0.6.4].

```
