### PR TITLE
Endless head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Fixed
+
+- A HEAD request with the curl handler can be endless
 
 ## 1.0.0 - 2016-07-18
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -72,7 +72,8 @@ class Client implements HttpClient
 
         $options['version'] = $request->getProtocolVersion();
         $options['headers'] = $request->getHeaders();
-        $options['body'] = (string) $request->getBody();
+        $body = (string) $request->getBody();
+        $options['body'] = '' === $body ? null : $body;
 
         return $this->client->createRequest(
             $request->getMethod(),

--- a/tests/HttpAdapterTest.php
+++ b/tests/HttpAdapterTest.php
@@ -3,6 +3,7 @@
 namespace Http\Adapter\Guzzle5\Tests;
 
 use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\Request;
 use Http\Adapter\Guzzle5\Client;
 use Http\Client\Tests\HttpClientTest;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
@@ -29,4 +30,16 @@ abstract class HttpAdapterTest extends HttpClientTest
      * @return object
      */
     abstract protected function createHandler();
+
+    /**
+     * @group integration
+     * @group network
+     */
+    public function testHeadRequestShouldEnd()
+    {
+        // It works with the PHP Built-in web server via $request = new Request('GET', $this->getUri());
+        $request = new Request('HEAD', 'https://httpbin.org/');
+        $this->httpAdapter->sendRequest($request);
+        $this->addToAssertionCount(1);
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | maybe
| Deprecations?   | no
| Related tickets | fixes #28 
| License         | MIT


#### What's in this PR?

Fix the send of a `HEAD` request with the curl handler.


#### Why?

At present, the `HEAD` request does not end. The stream handler don't have this behaviour and the PHP Built-in web server don't show this behaviour. For the moment, the test use a remote url.

The guzzle6-adapter has not this issue.

#### Example Usage

See example of #28


#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix


#### To Do

- [ ] Replace the remote url in test
