### PR TITLE
Fix PHPUnit_Framework_TestCase::getMock deprecation

### DIFF
--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -26,7 +26,7 @@ class ExceptionTest extends \PHPUnit_Framework_TestCase
 
     protected function makeRequest(GuzzleExceptions\TransferException $exception)
     {
-        $client = $this->getMock('GuzzleHttp\ClientInterface');
+        $client = $this->getMockBuilder('GuzzleHttp\ClientInterface')->getMock();
         $client->expects($this->any())->method('send')->willThrowException($exception);
         $client->expects($this->any())->method('createRequest')->willReturn($this->guzzleRequest);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

Use `getMockBuilder` instead of `getMock` in order to avoid 12 warnings during the launching of test suite:

```
There were 12 warnings:

1) Http\Adapter\Guzzle5\Tests\ExceptionTest::testConnectException
PHPUnit_Framework_TestCase::getMock() is deprecated, use PHPUnit_Framework_TestCase::createMock() or PHPUnit_Framework_TestCase::getMockBuilder() instead

...
```
