### PR TITLE
Support psr 18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ cache:
         - $HOME/.composer/cache/files
 
 php:
-    - 5.5
-    - 5.6
     - 7.0
+    - 7.1
+    - 7.2
     - hhvm
 
 env:
@@ -24,9 +24,6 @@ matrix:
     allow_failures:
         - php: hhvm
     fast_finish: true
-    include:
-        - php: 5.5
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
 
 before_install:
     - if [[ $COVERAGE != true && $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
     - 7.0
     - 7.1
     - 7.2
+    - 7.3
     - hhvm
 
 env:
@@ -24,6 +25,9 @@ matrix:
     allow_failures:
         - php: hhvm
     fast_finish: true
+    include:
+        - php: 7.0
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
 
 before_install:
     - if [[ $COVERAGE != true && $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## [2.0.0] - 2019-02-02
+
+### Added
+
+- Support for HTTPlug 2.0 and PSR-18
+
+### Changed
+
+- `\Http\Adapter\Guzzle5\Tests\ExceptionTest` extends `\PHPUnit\Framework\TestCase` instead of `PHPUnit_Framework_TestCase`
+
+### Removed
+
+- Support for PHP <7.0
+- Support for PHPUnit <6.0
+
 ## 1.0.1 - 2017-07-11
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^7.0",
         "php-http/httplug": "^1.0",
         "guzzlehttp/guzzle": "^5.1",
         "php-http/discovery": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "2.0-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     },
     "require-dev": {
         "ext-curl": "*",
+        "phpunit/phpunit": "^6.0 || ^7.0",
         "php-http/client-integration-tests": "^2.0",
         "guzzlehttp/ringphp": "^1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
     ],
     "require": {
         "php": "^7.0",
-        "php-http/httplug": "^1.0",
+        "php-http/httplug": "^2.0",
         "guzzlehttp/guzzle": "^5.1",
         "php-http/discovery": "^1.0"
     },
     "require-dev": {
         "ext-curl": "*",
-        "php-http/client-integration-tests": "^0.5.1",
+        "php-http/client-integration-tests": "^2.0",
         "guzzlehttp/ringphp": "^1.1"
     },
     "provide": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "guzzlehttp/ringphp": "^1.1"
     },
     "provide": {
-        "php-http/client-implementation": "1.0"
+        "php-http/client-implementation": "1.0",
+        "psr/http-client-implementation": "1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -43,7 +43,7 @@ class Client implements HttpClient
     /**
      * {@inheritdoc}
      */
-    public function sendRequest(RequestInterface $request)
+    public function sendRequest(RequestInterface $request): ResponseInterface
     {
         $guzzleRequest = $this->createRequest($request);
 

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -9,11 +9,12 @@ use GuzzleHttp\Psr7\Request as Psr7Request;
 use GuzzleHttp\Stream\Stream;
 use Http\Adapter\Guzzle5\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class ExceptionTest extends \PHPUnit_Framework_TestCase
+class ExceptionTest extends TestCase
 {
     private $guzzleRequest;
 
@@ -38,84 +39,84 @@ class ExceptionTest extends \PHPUnit_Framework_TestCase
     public function testConnectException()
     {
         // Guzzle's ConnectException should be converted to a NetworkException
-        $this->setExpectedException('Http\Client\Exception\NetworkException');
+        $this->expectException('Http\Client\Exception\NetworkException');
         $this->makeRequest(new GuzzleExceptions\ConnectException('foo', $this->guzzleRequest));
     }
 
     public function testTooManyRedirectsException()
     {
         // Guzzle's TooManyRedirectsException should be converted to a RequestException
-        $this->setExpectedException('Http\Client\Exception\RequestException');
+        $this->expectException('Http\Client\Exception\RequestException');
         $this->makeRequest(new GuzzleExceptions\TooManyRedirectsException('foo', $this->guzzleRequest));
     }
 
     public function testRequestException()
     {
         // Guzzle's RequestException should be converted to a HttpException
-        $this->setExpectedException('Http\Client\Exception\HttpException');
+        $this->expectException('Http\Client\Exception\HttpException');
         $this->makeRequest(new GuzzleExceptions\RequestException('foo', $this->guzzleRequest, $this->guzzleResponse));
     }
 
     public function testRequestExceptionWithoutResponse()
     {
         // Guzzle's RequestException with no response should be converted to a RequestException
-        $this->setExpectedException('Http\Client\Exception\RequestException');
+        $this->expectException('Http\Client\Exception\RequestException');
         $this->makeRequest(new GuzzleExceptions\RequestException('foo', $this->guzzleRequest));
     }
 
     public function testBadResponseException()
     {
         // Guzzle's BadResponseException should be converted to a HttpException
-        $this->setExpectedException('Http\Client\Exception\HttpException');
+        $this->expectException('Http\Client\Exception\HttpException');
         $this->makeRequest(new GuzzleExceptions\BadResponseException('foo', $this->guzzleRequest, $this->guzzleResponse));
     }
 
     public function testBadResponseExceptionWithoutResponse()
     {
         // Guzzle's BadResponseException with no response should be converted to a RequestException
-        $this->setExpectedException('Http\Client\Exception\RequestException');
+        $this->expectException('Http\Client\Exception\RequestException');
         $this->makeRequest(new GuzzleExceptions\BadResponseException('foo', $this->guzzleRequest));
     }
 
     public function testClientException()
     {
         // Guzzle's ClientException should be converted to a HttpException
-        $this->setExpectedException('Http\Client\Exception\HttpException');
+        $this->expectException('Http\Client\Exception\HttpException');
         $this->makeRequest(new GuzzleExceptions\ClientException('foo', $this->guzzleRequest, $this->guzzleResponse));
     }
 
     public function testClientExceptionWithoutResponse()
     {
         // Guzzle's ClientException with no response should be converted to a RequestException
-        $this->setExpectedException('Http\Client\Exception\RequestException');
+        $this->expectException('Http\Client\Exception\RequestException');
         $this->makeRequest(new GuzzleExceptions\ClientException('foo', $this->guzzleRequest));
     }
 
     public function testServerException()
     {
         // Guzzle's ServerException should be converted to a HttpException
-        $this->setExpectedException('Http\Client\Exception\HttpException');
+        $this->expectException('Http\Client\Exception\HttpException');
         $this->makeRequest(new GuzzleExceptions\ServerException('foo', $this->guzzleRequest, $this->guzzleResponse));
     }
 
     public function testServerExceptionWithoutResponse()
     {
         // Guzzle's ServerException with no response should be converted to a RequestException
-        $this->setExpectedException('Http\Client\Exception\RequestException');
+        $this->expectException('Http\Client\Exception\RequestException');
         $this->makeRequest(new GuzzleExceptions\BadResponseException('foo', $this->guzzleRequest));
     }
 
     public function testTransferException()
     {
         // Guzzle's TransferException should be converted to a TransferException
-        $this->setExpectedException('Http\Client\Exception\TransferException');
+        $this->expectException('Http\Client\Exception\TransferException');
         $this->makeRequest(new GuzzleExceptions\TransferException('foo'));
     }
 
     public function testParseException()
     {
         // Guzzle's ParseException should be converted to a TransferException
-        $this->setExpectedException('Http\Client\Exception\TransferException');
+        $this->expectException('Http\Client\Exception\TransferException');
         $this->makeRequest(new GuzzleExceptions\ParseException('foo', $this->guzzleResponse));
     }
 }

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -16,6 +16,7 @@ use Http\Message\MessageFactory\GuzzleMessageFactory;
 class ExceptionTest extends \PHPUnit_Framework_TestCase
 {
     private $guzzleRequest;
+
     private $guzzleResponse;
 
     public function setUp()


### PR DESCRIPTION
Update the adapter to require version 2.0 of both `php-http/httplug` and `php-http/client-integration-tests`. This will also add php 7.0 as a minimum requirement.

The Client is updated to comply with the interface of HttPlug 2.0.

Because of the requirement of php 7.0 PHPUnit will be used in a different version. Therefor I updated the `ExceptionTest` to use the correct PHPUnit interface and methods.

This fixes #34 

Side note; I'm not really experienced with open source contributions. If I forgot something or should change something please let me know.
